### PR TITLE
Add missing quote for the initial value of the global object property

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -150,7 +150,7 @@ contributors: Gus Caplan, Michael Ficarra, Kevin Gibbons
         <p>The <dfn>AsyncIterator</dfn> constructor:</p>
         <ul>
           <li>is <dfn>%AsyncIterator%</dfn>.</li>
-          <li>is the initial value of the *AsyncIterator* property of the global object.</li>
+          <li>is the initial value of the *"AsyncIterator"* property of the global object.</li>
           <li>is designed to be subclassable. It may be used as the value of an *extends* clause of a class definition.</li>
         </ul>
 


### PR DESCRIPTION
The spec uses double-quotation for the string property name when defining the initial value of the global object property.